### PR TITLE
[fix] Transfer rewards to users on withdraw_unbond

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -620,7 +620,13 @@ pub mod pallet {
 			ensure!(time_passed >= unbonding_delay, Error::<T>::UnbondingDelayNotPassed);
 
 			// withdraw the user deposit
-			let _ = <T as Config>::Currency::unreserve(&who, delegation.deposit);
+			let remaining_reward = <T as Config>::Currency::unreserve(&who, delegation.deposit);
+
+			// if any rewards was paid out to the user, we deposit the amount to the account
+			if remaining_reward != 0_u32.into() {
+				// transfer the user reward to user account
+				<T as Config>::Currency::deposit_creating(&who, remaining_reward);
+			}
 
 			// delete the unbonded delegation
 			UnbondedDelegates::<T>::remove(who.clone());
@@ -652,13 +658,27 @@ pub mod pallet {
 
 			// unreserve all delegators to the candidate
 			for delegator in delegation.delegators.iter() {
-				T::Currency::unreserve(&delegator.who, delegator.deposit);
+				// withdraw the user deposit
+				let remaining_reward =
+					<T as Config>::Currency::unreserve(&delegator.who, delegator.deposit);
+
+				// if any rewards was paid out to the user, we deposit the amount to the account
+				if remaining_reward != 0_u32.into() {
+					// transfer the user reward to user account
+					<T as Config>::Currency::deposit_creating(&delegator.who, remaining_reward);
+				}
 			}
 
 			<LastAuthoredBlock<T>>::remove(who.clone());
 
 			// withdraw the candidate deposit
-			let _ = <T as Config>::Currency::unreserve(&who, delegation.deposit);
+			let remaining_reward = <T as Config>::Currency::unreserve(&who, delegation.deposit);
+
+			// if any rewards was paid out to the candidate, we deposit the amount to the account
+			if remaining_reward != 0_u32.into() {
+				// transfer the user reward to user account
+				<T as Config>::Currency::deposit_creating(&who, remaining_reward);
+			}
 
 			// delete the unbonded delegation
 			UnbondedCandidates::<T>::remove(who.clone());

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -226,7 +226,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 	let invulnerables = vec![1, 2];
 
-	let balances = vec![(1, 100), (2, 100), (3, 100), (4, 100), (5, 100)];
+	let balances = vec![(1, 100), (2, 100), (3, 100), (4, 100), (5, 100), (100, 100)];
 	let keys = balances
 		.iter()
 		.map(|&(i, _)| (i, i, MockSessionKeys { aura: UintAuthorityId(i) }))

--- a/runtime/bitgreen/src/lib.rs
+++ b/runtime/bitgreen/src/lib.rs
@@ -112,7 +112,7 @@ pub type Executive = frame_executive::Executive<
 	Runtime,
 	AllPalletsWithSystem,
 	// Migrations
-	()
+	(),
 >;
 
 pub type NegativeImbalance<T> = <pallet_balances::Pallet<T> as Currency<


### PR DESCRIPTION
Changelog:
- Ensure the rewards are transferred when unbonding is done by the collator